### PR TITLE
fix: send data to backend even if there are no snakes left

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "start": "npm run serve",
     "serve": "live-server dist",
     "dev": "run-p tsc:watch bundle:watch copy:public:watch serve",
-    "dev:mock": "run-p tsc:watch bundle:watch copy:public:watch serve mock-server",
+    "dev:mock": "run-p dev mock-server",
     "build": "run-s tsc bundle copy:public",
     "build:watch": "run-s tsc:watch bundle:watch copy:public:watch",
     "tsc": "tsc",

--- a/frontend/src/world.ts
+++ b/frontend/src/world.ts
@@ -98,9 +98,7 @@ export class World implements MessageListener {
 
     // send "snakes" message?
     if (this.tickCount % AI_CALL_FREQUENCY === 0 && this.pendingWebSocketRequests.length === 0) {
-      if (this.aliveSnakes.length > 0) {
-        this.sendWebSocketMessage(MessageType.DATA, this.currentSnakesData());
-      }
+      this.sendWebSocketMessage(MessageType.DATA, this.currentSnakesData());
     }
 
     this.tickCount++;

--- a/frontend/websocket-server.js
+++ b/frontend/websocket-server.js
@@ -2,18 +2,30 @@ const WebSocket = require('ws');
 
 const wss = new WebSocket.Server({ port: 8765 });
 
+const MESSAGE_TYPES = {
+  GENERATION: 'generation',
+  DATA: 'data'
+};
+
 let genCount = 0;
 let frameCount = 0;
-const GEN_COUNT = 10;
+const GEN_COUNT = 200;
 
 wss.on('connection', function connection(ws) {
   ws.on('message', function incoming(message) {
     const data = JSON.parse(message);
     console.log(`[SERVER]: <<< received message of type ${data.type} and ID ${data.messageId}`);
-    if (data.type === 'generation') {
+    if (data.type === MESSAGE_TYPES.GENERATION) {
       setTimeout(() => {
-        ws.send(JSON.stringify({ messageId: data.messageId, type: 'generation', data: { generation: ++genCount} }));
+        ws.send(JSON.stringify({ messageId: data.messageId, type: MESSAGE_TYPES.GENERATION, data: { generation: ++genCount} }));
       }, 500);
+    } else if (frameCount >= GEN_COUNT || Object.keys(data.data).length === 0) {
+      frameCount = 0;
+      ws.send(JSON.stringify({
+        messageId: -1,
+        type: MESSAGE_TYPES.GENERATION,
+        data: { generation: genCount++ },
+      }));
     } else {
       const ids = Object.keys(data.data);
       const resultData = ids.map(id => ({ [id]: [(Math.random() - 0.5) * 2, (Math.random() - 0.5) * 2] })).reduce((acc, pos) => ({...acc, ...pos}), {});
@@ -21,25 +33,16 @@ wss.on('connection', function connection(ws) {
       // const x = Math.cos(Date.now() / 800);
       // const y = Math.sin(Date.now() / 800);
       // const resultData = ids.map(id => ({ [id]: [x, y] })).reduce((acc, pos) => ({...acc, ...pos}), {});
-      if (frameCount >= GEN_COUNT) {
-        frameCount = 0;
+      setTimeout(() => {
         ws.send(JSON.stringify({
-          messageId: -1,
-          type: 'generation',
-          data: { generation: genCount++ },
+          messageId: data.messageId,
+          type: MESSAGE_TYPES.DATA,
+          data: {
+            prediction: resultData,
+            progress: frameCount++ / GEN_COUNT,
+          },
         }));
-      } else {
-        setTimeout(() => {
-          ws.send(JSON.stringify({
-            messageId: data.messageId,
-            type: 'data',
-            data: {
-              prediction: resultData,
-              progress: frameCount++ / GEN_COUNT,
-            },
-          }));
-        }, 20);
-      }
+      }, 20);
     }
   });
 });


### PR DESCRIPTION
Until now the frontend stopped sending data if there were no snakes left. From my understanding of the way we count frames and the way we start new generations this doesn't make any sense. There is no way for the backend to know that all snakes died - and hence it waits for the next frame(s) to finish the current generation forever since the frontend doesn't send any data so the backend does not progress in frames. I confused. @azacha Let's talk about this 👍 